### PR TITLE
update tls to 1.2 version

### DIFF
--- a/lib/slack/incoming/webhooks/connection.rb
+++ b/lib/slack/incoming/webhooks/connection.rb
@@ -9,7 +9,7 @@ module Slack
         uri = URI.parse(webhook_url)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
-        http.ssl_version = :TLSv1
+        http.ssl_version = :TLSv1_2
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         http
       end


### PR DESCRIPTION
More info: https://api.slack.com/changelog/2019-07-deprecate-early-tls-versions